### PR TITLE
Fixed context error when casting video for the first time

### DIFF
--- a/google-castable-video.html
+++ b/google-castable-video.html
@@ -281,7 +281,7 @@ Instead of listening for the video element's `timeupdate` event please listen fo
                if (el.getAttribute("src").split('/').pop()===this.currentSrc.split('/').pop()) {
                 mediaInfo.contentType = el.getAttribute('type');
                }
-              }
+              }.bind(this)
             );
             var request = new chrome.cast.media.LoadRequest(mediaInfo);
             this._session.loadMedia(request,


### PR DESCRIPTION
While trying to cast a video for the first time I get the following error:

```
Uncaught TypeError: 
Cannot read property 'split' of undefined
(anonymous function) @ google-castable-video.html:281
Polymer.play @ google-castable-video.html:277
(anonymous function) @ (index):34
```
